### PR TITLE
Bug fix - trim whitespace for bad words.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 (function () {
   'use strict';
   var winston = module.parent.require('winston'),
+  _ = require('underscore'),
   fs = require('fs'),
   path = require('path'),
-  meta = module.parent.require('./meta'),
-  Beep = {
+  meta = module.parent.require('./meta');
+
+  _.str = require('underscore.string');
+  _.mixin(_.str.exports()); // Mix in non-conflict functions to Underscore namespace
+  var Beep = {
     banned_words: undefined,
     init: function (app, middleware, controllers, callback) {
       function render(req, res, next) {
@@ -40,6 +44,7 @@
     },
     parse: function (postContent, callback) {
       var badwords = Beep.banned_words.split(',');
+      badwords = _.map(badwords, function(word) { return _.trim(word); });
       for (var w in badwords) {
         var re = new RegExp(badwords[w], 'ig');
         var hidesting = '';
@@ -63,7 +68,7 @@
           'name': 'Censor Curse Words'
         });
         callback(null, custom_header);
-      },
+      }
     }
   };
   module.exports = Beep;

--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
   "readme": "",
   "readmeFilename": "README.md",
   "_id": "nodebb-plugin-beep@0.0.1",
-  "_from": "nodebb-plugin-beep@~0.0.1"
+  "_from": "nodebb-plugin-beep@~0.0.1",
+  "dependencies": {
+    "underscore": "^1.7.0",
+    "underscore.string": "^2.3.3"
+  }
 }


### PR DESCRIPTION
Trim whitespaces for words in the word list.  This is so that a list with spaces after the comma ("anus, ass, anal") will work properly.
