### PR TITLE
Bug fix - Breadcrumb html should not be censored.

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -116,7 +116,7 @@
       });
       //Change Breadcrumb
       var rnotwhite = /\S/;
-      $('ol.breadcrumb li span').contents().filter(function() {
+      $('ol.breadcrumb li span, ol.breadcrumb li').contents().filter(function() {
         return this.nodeType === 3 && rnotwhite.test($(this).text()); // Filter out empty text nodes. We only want text nodes with text.
       }).text(function(i, text) {
         var match = text.match(re);


### PR DESCRIPTION
This is a bug fix for the censor breaking the html in the breadcrumb.  The censor should only apply to text inside the breadcrumb and not the html.  Here's an example of the bug:

Original html:

``` html
<span itemprop="title">
  Category 1 
  <a target="_blank" href="/category/1.rss">
    <i class="fa fa-rss-square"></i>
  </a>
</span>
```

Resulting html (the `class` gets turned into `cla**` because `ass` is in the word list):

``` html
<span itemprop="title">
  Category 1 
  <a target="_blank" href="/category/1.rss">
    <i cla**="fa fa-rss-square"></i>
  </a>
</span>
```
