### PR TITLE
Major speed fix to censorTopics

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,19 @@
             Beep.loadList();
             callback();
         },
+        appendConfig: function(config, callback) {
+            meta.settings.getOne('beep', 'censorWholeWord', function(err, censorWholeWord) {
+                if (err) {
+                    return callback(null, config);
+                }
+
+                config.beep = {
+                    censorWholeWord: censorWholeWord
+                }
+
+                callback(err, config);
+            });
+        },
         loadList: function() {
             // Load Banned Words from config
             meta.settings.get('beep', function(err, hash) {

--- a/plugin.json
+++ b/plugin.json
@@ -12,7 +12,8 @@
 		{ "hook": "action:settings.set", "method": "onListChange" },
 		{ "hook": "filter:admin.header.build", "method": "admin.menu" },
 		{ "hook": "filter:topic.post", "method": "checkForIllegalWords" },
-		{ "hook": "filter:topic.reply", "method": "checkForIllegalWords" }
+		{ "hook": "filter:topic.reply", "method": "checkForIllegalWords" },
+		{ "hook": "filter:config.get", "method": "appendConfig" }
 	],
 	"scripts": [
 		"static/main.js"

--- a/static/main.js
+++ b/static/main.js
@@ -81,7 +81,7 @@
             if (data.url.match(/^category/) || data.url.match(/^unread/) || data.url.match(/^recent/) || data.url.match(/^popular/) || data.url.match(/^topic/)) {
                 censorTopics();
             }
-            if (data.url.match(/^topic/)) $(window).on('scroll', censorTopics);
+            if (data.url.match(/^topic/)) $(window).on('action:infinitescroll.loadmore', censorTopics);
             if (data.url.match(/^chats/)) censorChatTeaser();
         });
         $(window).on('action:categories.loaded', censorTopics);

--- a/static/main.js
+++ b/static/main.js
@@ -97,74 +97,67 @@
     });
 
     function censorTopics() {
-        for (var w in badwords) {
-            var re = new RegExp(badwords[w], 'ig');
-            var hidesting = '';
-            for (var i = 0; i < badwords[w].length - 2; i++) {
-                hidesting += '*';
+        var workingEl;
+        var censor = function(match) {
+            if (!config.beep.censorWholeWord) {
+                return match[0] + Array(match.length-1).join('*') + match[match.length-1];
+            } else {
+                return '[censored]';
             }
-            var re2 = new RegExp(badwords[w].substring(1, badwords[w].length - 1), 'ig');
-            //Change topic title on topic list and topic
-            $('[component="post"] .topic-title, [component="topic/header"] [itemprop="url"], [component="post/header"] > *').each(function() {
-                if (re.test($(this).html())){
-                    var match = $(this).html().match(re);
-                    var hashword = match[0].replace(re2, hidesting);
-                    $(this).html($(this).html().replace(re, hashword));
-                }
-            });
-            //Change Breadcrumb
-            var rnotwhite = /\S/;
-            $('ol.breadcrumb li span, ol.breadcrumb li').contents().filter(function() {
-                return this.nodeType === 3 && rnotwhite.test($(this).text()); // Filter out empty text nodes. We only want text nodes with text.
-            }).text(function(i, text) {
-                var match = text.match(re);
-                if (match && match.length > 0) {
-                    var hashword = match[0].replace(re2, hidesting);
-                    this.nodeValue = text.replace(re, hashword);
-                }
-            });
-            //Change header information
-            $('.header-topic-title span').each(function() {
-                if (re.test($(this).html())){
-                    var match = $(this).html().match(re);
-                    var hashword = match[0].replace(re2, hidesting);
-                    $(this).html($(this).html().replace(re, hashword));
-                }
-            });
-            if (re.test(document.title)){
-                var match = document.title.match(re);
-                var hashword = match[0].replace(re2, hidesting);
-                document.title = document.title.replace(re, hashword);
+        };
+
+        var re = new RegExp('\\b(' + badwords.join('|') + ')\\b', 'ig');
+
+        //Change topic title on topic list and topic
+        $('[component="post"] .topic-title, [component="topic/header"] [itemprop="url"], [component="post/header"] > *').each(function() {
+            workingEl = $(this);
+            workingEl.html(workingEl.html().replace(re, censor));
+        });
+
+        //Change Breadcrumb
+        var rnotwhite = /\S/;
+        $('ol.breadcrumb li span, ol.breadcrumb li').contents().filter(function() {
+            return this.nodeType === 3 && rnotwhite.test($(this).text()); // Filter out empty text nodes. We only want text nodes with text.
+        }).text(function(i, text) {
+            var match = text.match(re);
+            if (match && match.length > 0) {
+                // var hashword = match[0].replace(re2, hidestring);
+                this.nodeValue = text.replace(re, censor);
             }
+        });
 
-            // Meta title and og:title
-            $('meta[name="title"], meta[property="og:title"]').each(function() {
-                var title = $(this).attr('content');
-                if (title) {
-                    var match = title.match(re);
-                    if (match && match.length > 0) {
-                        var hashword = match[0].replace(re2, hidesting);
-                        $(this).attr('content', title.replace(re, hashword));
-                    }
-                }
-            });
+        //Change header information
+        $('.header-topic-title span').each(function() {
+            workingEl = $(this);
+            workingEl.html(workingEl.html().replace(re, censor));
+        });
 
-        }
+        document.title = document.title.replace(re, censor);
+
+        // Meta title and og:title
+        $('meta[name="title"], meta[property="og:title"]').each(function() {
+            var title = $(this).attr('content');
+            if (title) {
+                workingEl = $(this);
+                workingEl.attr('content', title.replace(re, censor));
+            }
+        });
     }
+
     // Has to be a better way of doing this :/
     function censorChatTeaser(){
         for (var w in badwords) {
             var re = new RegExp(badwords[w], 'ig');
-            var hidesting = '';
+            var hidestring = '';
             for (var i = 0; i < badwords[w].length - 2; i++) {
-                hidesting += '*';
+                hidestring += '*';
             }
             var re2 = new RegExp(badwords[w].substring(1, badwords[w].length - 1), 'ig');
             // Last Chat teaser
             $('[component="chat/recent"] .teaser-content').each(function() {
                 if (re.test($(this).html())){
                     var match = $(this).html().match(re);
-                    var hashword = match[0].replace(re2, hidesting);
+                    var hashword = match[0].replace(re2, hidestring);
                     $(this).html($(this).html().replace(re, hashword));
                 }
             });

--- a/static/main.js
+++ b/static/main.js
@@ -81,7 +81,11 @@
             if (data.url.match(/^category/) || data.url.match(/^unread/) || data.url.match(/^recent/) || data.url.match(/^popular/) || data.url.match(/^topic/) || data.url.match(/^user/)) {
                 censorTopics();
             }
-            if (data.url.match(/^topic/)) $(window).on('action:infinitescroll.loadmore', censorTopics);
+            if (data.url.match(/^topic/)) {
+                $(window).on('action:infinitescroll.loadmore', censorTopics);
+            } else {
+                $(window).off('action:infinitescroll.loadmore', censorTopics);
+            }
             if (data.url.match(/^chats/)) censorChatTeaser();
         });
         $(window).on('action:categories.loaded', censorTopics);


### PR DESCRIPTION
A couple changes here, so let me summarize the diff, which is probably a little much at first glance:

* I am now appending the `censorWholeWord` config to `window.config`, and this is an extension of my last pull request
* No longer calling `censorTopics` on every tick of the mousewheel. Assumed this was done to catch cases where topics are loaded via infinite scroll. Well, we have a client-side event for that, so I listen to that now 😄  
* Noticed `re` and `re2` were being instantiated on every single banned word. Updated the code to create a single instance of `re` with all of the banned words, and removed need for `re2`
* Fixed `hidesting` typo

For the 2nd item, this fixed the latency in the topics view. It was getting pretty bad if your banned words list was fairly large.

For the 3rd, this reduced the average runtime of `censorTopics` from ~300ms to ~4ms.