### PR TITLE
Fix for reply/quote where postTitle does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,8 +131,8 @@
             });
 
             for (var w in illegal_words) {
-                
-                if (postTitle.toLowerCase().match(illegal_words[w])){
+
+                if (postTitle && postTitle.toLowerCase().match(illegal_words[w])){
                     return callback(new Error('You may not use the word "' + illegal_words[w] + '" in your title.'));
                 }
 


### PR DESCRIPTION
When replying to or quoting a post, the postTitle fix would break since no postTitle exists!