### PR TITLE
fix callback already called errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,15 +148,6 @@ var Beep = {
 
 		callback(null, data);
 	},
-	parseTopic: function (topic) {
-		var starHTML = '&#8270;';
-		if (topic) {
-			topic.title = Beep.parseContent(topic.title, starHTML);
-			topic.slug = Beep.parseContent(topic.slug, starHTML);
-			topic.titleRaw = Beep.parseContent(topic.titleRaw, starHTML);
-		}
-		return topic;
-	},
 	filterTags: function (data, callback) {
 		var match;
 		data.tags.some(function (tag) {

--- a/index.js
+++ b/index.js
@@ -114,6 +114,9 @@ var Beep = {
 			return callback(null, data);
 		}
 		data.postData.content = Beep.parseContent(data.postData.content);
+		if (data.postData.topic) {
+			Beep.parseTopic(data.postData.topic)
+		}
 		callback(null, data);
 	},
 	parseRaw: function (content, callback) {
@@ -130,14 +133,30 @@ var Beep = {
 		data.userData.signature = Beep.parseContent(data.userData.signature);
 		callback(null, data);
 	},
-	parseTopic: function (data, callback) {
-  	// from http://htmlarrows.com/symbols/
-		var starHTML = '&#8270;';
-		data.topic.title = Beep.parseContent(data.topic.title, starHTML);
-		data.topic.slug = Beep.parseContent(data.topic.slug, starHTML);
-		data.topic.titleRaw = Beep.parseContent(data.topic.titleRaw, starHTML);
-
+	onTopicsGet: function (data, callback) {
+		data.topics.forEach(Beep.parseTopic);
 		callback(null, data);
+	},
+	onTopicGet: function (data, callback) {
+		Beep.parseTopic(data.topic);
+		callback(null, data);
+	},
+	onGetPostSummaries: function (data, callback) {
+		data.posts.forEach(function (post) {
+			if (post) {
+				Beep.parseTopic(post.topic);
+			}
+		});
+		callback(null, data);
+	},
+	parseTopic: function (topic) {
+		var starHTML = '&#8270;';
+		if (topic) {
+			topic.title = Beep.parseContent(topic.title, starHTML);
+			topic.slug = Beep.parseContent(topic.slug, starHTML);
+			topic.titleRaw = Beep.parseContent(topic.titleRaw, starHTML);
+		}
+		return topic;
 	},
 	filterTags: function (data, callback) {
 		var match;

--- a/index.js
+++ b/index.js
@@ -120,9 +120,6 @@ var Beep = {
 			return callback(null, data);
 		}
 		data.postData.content = Beep.parseContent(data.postData.content);
-		if (data.postData.topic) {
-			Beep.parseTopic(data.postData.topic)
-		}
 		callback(null, data);
 	},
 	parseRaw: function (content, callback) {

--- a/index.js
+++ b/index.js
@@ -97,15 +97,17 @@ var Beep = {
 
 		var titleMatch = postTitle && postTitle.match(Beep.illegal_words);
 		if (titleMatch) {
-			return translator.translate('[[beep:titleMatch.error, ' + titleMatch[0] + ']]', function (translated) {
+			translator.translate('[[beep:titleMatch.error, ' + titleMatch[0] + ']]', function (translated) {
 				callback(new Error(translated));
 			});
+			return;
 		}
 		var contentMatch = postContent && postContent.match(Beep.illegal_words);
 		if (contentMatch) {
-			return translator.translate('[[beep:contentMatch.error, ' + contentMatch[0] + ']]', function (translated) {
+			translator.translate('[[beep:contentMatch.error, ' + contentMatch[0] + ']]', function (translated) {
 				callback(new Error(translated));
 			});
+			return;
 		}
 
 		callback(null, data);
@@ -153,9 +155,10 @@ var Beep = {
 		});
 
 		if (match) {
-			return translator.translate('[[beep:tagMatch.error, ' + match[0] + ']]', function (translated) {
+			translator.translate('[[beep:tagMatch.error, ' + match[0] + ']]', function (translated) {
 				callback(new Error(translated));
 			});
+			return;
 		}
 
 		data.tags = data.tags.map(function (tag) {

--- a/plugin.json
+++ b/plugin.json
@@ -16,8 +16,10 @@
 		{ "hook": "filter:parse.signature", "method": "parseSignature" },
 		{ "hook": "filter:post.getFields", "method": "post.getFields"},
 
-		{ "hook": "filter:topic.create", "method": "parseTopic" },
-		{ "hook": "filter:topic.edit", "method": "parseTopic" },
+		{ "hook": "filter:topics.get", "method": "onTopicsGet" },
+		{ "hook": "filter:topic.get", "method": "onTopicGet" },
+		{ "hook": "filter:post.getPostSummaryByPids", "method": "onGetPostSummaries" },
+
 		{ "hook": "filter:tags.filter", "method": "filterTags" },
 
 		{ "hook": "filter:topic.create", "method": "checkForIllegalWords" },

--- a/plugin.json
+++ b/plugin.json
@@ -16,10 +16,8 @@
 		{ "hook": "filter:parse.signature", "method": "parseSignature" },
 		{ "hook": "filter:post.getFields", "method": "post.getFields"},
 
-		{ "hook": "filter:topics.get", "method": "onTopicsGet" },
-		{ "hook": "filter:topic.get", "method": "onTopicGet" },
-		{ "hook": "filter:post.getPostSummaryByPids", "method": "onGetPostSummaries" },
-
+		{ "hook": "filter:topic.create", "method": "parseTopic" },
+		{ "hook": "filter:topic.edit", "method": "parseTopic" },
 		{ "hook": "filter:tags.filter", "method": "filterTags" },
 
 		{ "hook": "filter:topic.create", "method": "checkForIllegalWords" },


### PR DESCRIPTION
```
2020-12-17T10:54:20.025Z [4567/127] - error: uncaughtException: Callback was already called.
nodebb                       | Error: Callback was already called.
nodebb                       |     at /usr/src/app/node_modules/async/dist/async.js:318:36
nodebb                       |     at /usr/src/app/node_modules/async/dist/async.js:1633:17
nodebb                       |     at Timeout._onTimeout (/usr/src/app/node_modules/nodebb-plugin-beep/index.js:107:5)
```

```
return translator.translate('[[beep:titleMatch.error, ' + titleMatch[0] + ']]', function (translated) {
	callback(new Error(translated));
});
```

Above code causes the callback to be called twice since `translator.translate` returns a promise to core and core handles this by calling the callback. Moving the return after the translate fixes this.

