### PR TITLE
Only set topic fields if they already exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,9 +141,18 @@ var Beep = {
 	parseTopic: function (data, callback) {
 		// from http://htmlarrows.com/symbols/
 		var starHTML = '*';
-		data.topic.title = Beep.parseContent(data.topic.title, starHTML);
-		data.topic.slug = Beep.parseContent(data.topic.slug, starHTML);
-		data.topic.titleRaw = Beep.parseContent(data.topic.titleRaw, starHTML);
+		
+    if (data.topic.hasOwnProperty('title')) {
+      data.topic.title = Beep.parseContent(data.topic.title, starHTML);
+    }
+		
+    if (data.topic.hasOwnProperty('slug')) {
+      data.topic.slug = Beep.parseContent(data.topic.slug, starHTML);
+    }
+		
+    if (data.topic.hasOwnProperty('titleRaw')) {
+      data.topic.titleRaw = Beep.parseContent(data.topic.titleRaw, starHTML);
+    }
 
 		callback(null, data);
 	},


### PR DESCRIPTION
Restoring a previous version of a topic with the Edit History function was deleting the title and slug. This fix only sets the fields if they already exist to avoid deleting the values.